### PR TITLE
Add Clarity 4 emoji-battle game with tests”

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,23 @@
+# Stacks Arcade
+
+Playground of Stacks smart-contract mini-games with a matching Next.js frontend and curated learning resources.
+
+## Layout
+- `stacks-arcade/` — Clarity contracts for each mini-game plus Vitest suites (`npm test`) and Clarinet config.
+- `frontend/` — Next.js app for the arcade UI (`npm run dev`, `npm run build`).
+- `docs/` — Short gameplay and contract notes (e.g., `docs/games/coin-flip.md`).
+- `stacks/` — Stacks knowledge base with a quick index at `stacks/INDEX.md`.
+
+## Quickstart
+1. Install dependencies:
+   - `cd stacks-arcade && npm install`
+   - `cd frontend && npm install`
+2. Run contract tests from `stacks-arcade/`:
+   - `npm test` for unit tests
+   - `npm run test:report` for coverage and cost output
+3. Run the frontend from `frontend/`:
+   - `npm run dev` then open `http://localhost:3000`
+
+## Notes
+- Node.js 18+ is recommended for both workspaces.
+- Clarinet CLI is optional for extra contract inspection; core tests run via `vitest` with the Clarinet SDK environment.

--- a/stacks-arcade/contracts/emoji-battle.clar
+++ b/stacks-arcade/contracts/emoji-battle.clar
@@ -173,3 +173,16 @@
       (print {event: "claim", player: recipient, amount: amount})
       (ok true))))
 
+;; read only functions
+(define-read-only (get-next-game-id)
+  (var-get next-game-id))
+
+(define-read-only (get-game (game-id uint))
+  (map-get? games {id: game-id}))
+
+(define-read-only (get-balance (who principal))
+  (default-to u0 (get amount (map-get? balances {player: who}))))
+
+(define-read-only (get-version)
+  contract-version)
+

--- a/stacks-arcade/contracts/emoji-battle.clar
+++ b/stacks-arcade/contracts/emoji-battle.clar
@@ -164,3 +164,12 @@
       (ok true))
     err-not-found))
 
+(define-public (claim)
+  (let ((amount (default-to u0 (get amount (map-get? balances {player: tx-sender})))))
+    (asserts! (> amount u0) err-zero-claim)
+    (let ((recipient tx-sender))
+      (unwrap! (as-contract? ((with-stx amount)) (try! (stx-transfer? amount tx-sender recipient))) err-transfer)
+      (map-set balances {player: tx-sender} {amount: u0})
+      (print {event: "claim", player: recipient, amount: amount})
+      (ok true))))
+

--- a/stacks-arcade/deployments/default.simnet-plan.yaml
+++ b/stacks-arcade/deployments/default.simnet-plan.yaml
@@ -1,0 +1,116 @@
+---
+id: 0
+name: "Simulated deployment, used as a default for `clarinet console`, `clarinet test` and `clarinet check`"
+network: simnet
+genesis:
+  wallets:
+    - name: deployer
+      address: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
+      balance: "100000000000000"
+      sbtc-balance: "1000000000"
+    - name: faucet
+      address: STNHKEPYEPJ8ET55ZZ0M5A34J0R3N5FM2CMMMAZ6
+      balance: "100000000000000"
+      sbtc-balance: "1000000000"
+    - name: wallet_1
+      address: ST1SJ3DTE5DN7X54YDH5D64R3BCB6A2AG2ZQ8YPD5
+      balance: "100000000000000"
+      sbtc-balance: "1000000000"
+    - name: wallet_2
+      address: ST2CY5V39NHDPWSXMW9QDT3HC3GD6Q6XX4CFRK9AG
+      balance: "100000000000000"
+      sbtc-balance: "1000000000"
+    - name: wallet_3
+      address: ST2JHG361ZXG51QTKY2NQCVBPPRRE2KZB1HR05NNC
+      balance: "100000000000000"
+      sbtc-balance: "1000000000"
+    - name: wallet_4
+      address: ST2NEB84ASENDXKYGJPQW86YXQCEFEX2ZQPG87ND
+      balance: "100000000000000"
+      sbtc-balance: "1000000000"
+    - name: wallet_5
+      address: ST2REHHS5J3CERCRBEPMGH7921Q6PYKAADT7JP2VB
+      balance: "100000000000000"
+      sbtc-balance: "1000000000"
+    - name: wallet_6
+      address: ST3AM1A56AK2C1XAFJ4115ZSV26EB49BVQ10MGCS0
+      balance: "100000000000000"
+      sbtc-balance: "1000000000"
+    - name: wallet_7
+      address: ST3PF13W7Z0RRM42A8VZRVFQ75SV1K26RXEP8YGKJ
+      balance: "100000000000000"
+      sbtc-balance: "1000000000"
+    - name: wallet_8
+      address: ST3NBRSFKX28FQ2ZJ1MAKX58HKHSDGNV5N7R21XCP
+      balance: "100000000000000"
+      sbtc-balance: "1000000000"
+  contracts:
+    - genesis
+    - lockup
+    - bns
+    - cost-voting
+    - costs
+    - pox
+    - costs-2
+    - pox-2
+    - costs-3
+    - pox-3
+    - pox-4
+    - signers
+    - signers-voting
+    - costs-4
+plan:
+  batches:
+    - id: 0
+      transactions:
+        - emulated-contract-publish:
+            contract-name: coin-flip
+            emulated-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
+            path: contracts/coin-flip.clar
+            clarity-version: 4
+        - emulated-contract-publish:
+            contract-name: emoji-battle
+            emulated-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
+            path: contracts/emoji-battle.clar
+            clarity-version: 4
+        - emulated-contract-publish:
+            contract-name: guess-the-number
+            emulated-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
+            path: contracts/guess-the-number.clar
+            clarity-version: 4
+        - emulated-contract-publish:
+            contract-name: higher-lower
+            emulated-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
+            path: contracts/higher-lower.clar
+            clarity-version: 4
+        - emulated-contract-publish:
+            contract-name: hot-potato
+            emulated-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
+            path: contracts/hot-potato.clar
+            clarity-version: 4
+        - emulated-contract-publish:
+            contract-name: lottery-demo
+            emulated-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
+            path: contracts/lottery-demo.clar
+            clarity-version: 4
+        - emulated-contract-publish:
+            contract-name: rock-paper-scissors
+            emulated-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
+            path: contracts/rock-paper-scissors.clar
+            clarity-version: 4
+        - emulated-contract-publish:
+            contract-name: scoreboard
+            emulated-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
+            path: contracts/scoreboard.clar
+            clarity-version: 4
+        - emulated-contract-publish:
+            contract-name: tic-tac-toe
+            emulated-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
+            path: contracts/tic-tac-toe.clar
+            clarity-version: 4
+        - emulated-contract-publish:
+            contract-name: todo-list
+            emulated-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
+            path: contracts/todo-list.clar
+            clarity-version: 4
+      epoch: "3.3"

--- a/stacks-arcade/tests/coin-flip.test.ts
+++ b/stacks-arcade/tests/coin-flip.test.ts
@@ -1,4 +1,3 @@
-tests/coin-flip.test.ts
 // Import Clarity types and utilities for contract interactions
 import { Cl, ClarityType, SomeCV, TupleCV, UIntCV } from "@stacks/transactions";
 // Import vitest testing utilities

--- a/stacks-arcade/tests/emoji-battle.test.ts
+++ b/stacks-arcade/tests/emoji-battle.test.ts
@@ -1,21 +1,155 @@
 
+import { Cl, ClarityType, SomeCV, TupleCV, UIntCV } from "@stacks/transactions";
 import { describe, expect, it } from "vitest";
 
 const accounts = simnet.getAccounts();
-const address1 = accounts.get("wallet_1")!;
+const wallet1 = accounts.get("wallet_1")!;
+const wallet2 = accounts.get("wallet_2")!;
 
-/*
-  The test below is an example. To learn more, read the testing documentation here:
-  https://docs.hiro.so/stacks/clarinet-js-sdk
-*/
+const contractName = "emoji-battle";
+const stake = 1_000_000n;
 
-describe("example tests", () => {
-  it("ensures simnet is well initialised", () => {
-    expect(simnet.blockHeight).toBeDefined();
+const extractGameId = (response: { value: UIntCV }) => Number(response.value.value);
+
+const getGameTuple = (gameId: number) => {
+  const entry = simnet.getMapEntry(contractName, "games", Cl.tuple({ id: Cl.uint(gameId) }));
+  expect(entry).toHaveClarityType(ClarityType.OptionalSome);
+  return (entry as SomeCV<TupleCV>).value;
+};
+
+const createGame = (creator: string, emoji: string, wager: bigint = stake) => {
+  const create = simnet.callPublicFn(
+    contractName,
+    "create-game",
+    [Cl.uint(wager), Cl.stringAscii(emoji)],
+    creator,
+  );
+  expect(create.result).toHaveClarityType(ClarityType.ResponseOk);
+  return extractGameId(create.result as any);
+};
+
+describe("emoji-battle", () => {
+  it("rejects invalid emoji on create", () => {
+    const res = simnet.callPublicFn(
+      contractName,
+      "create-game",
+      [Cl.uint(stake), Cl.stringAscii("invalid")],
+      wallet1,
+    );
+    expect(res.result).toBeErr(Cl.uint(400));
   });
 
-  // it("shows an example", () => {
-  //   const { result } = simnet.callReadOnlyFn("counter", "get-counter", [], address1);
-  //   expect(result).toBeUint(0);
-  // });
+  it("settles a battle with a clear winner", () => {
+    // fire beats leaf
+    const gameId = createGame(wallet1, "fire");
+    const join = simnet.callPublicFn(
+      contractName,
+      "join-game",
+      [Cl.uint(gameId), Cl.stringAscii("leaf")],
+      wallet2,
+    );
+    expect(join.result).toHaveClarityType(ClarityType.ResponseOk);
+
+    const game = getGameTuple(gameId);
+    expect(game.value.creator).toEqual(Cl.standardPrincipal(wallet1));
+    expect(game.value.challenger).toEqual(Cl.some(Cl.standardPrincipal(wallet2)));
+    expect(game.value.stake).toEqual(Cl.uint(stake));
+    expect(game.value.emoji1).toEqual(Cl.stringAscii("fire"));
+    expect(game.value.emoji2).toEqual(Cl.some(Cl.stringAscii("leaf")));
+    expect(game.value.status).toEqual(Cl.uint(1));
+    expect(game.value.winner).toEqual(Cl.some(Cl.standardPrincipal(wallet1)));
+    expect(game.value.result).toEqual(Cl.stringAscii("creator"));
+
+    const creatorBalance = simnet.callReadOnlyFn(
+      contractName,
+      "get-balance",
+      [Cl.standardPrincipal(wallet1)],
+      wallet1,
+    );
+    expect(creatorBalance.result).toBeUint(stake * 2n);
+    const challengerBalance = simnet.callReadOnlyFn(
+      contractName,
+      "get-balance",
+      [Cl.standardPrincipal(wallet2)],
+      wallet2,
+    );
+    expect(challengerBalance.result).toBeUint(0);
+  });
+
+  it("refunds both players on a tie", () => {
+    const gameId = createGame(wallet1, "water");
+    const join = simnet.callPublicFn(
+      contractName,
+      "join-game",
+      [Cl.uint(gameId), Cl.stringAscii("water")],
+      wallet2,
+    );
+    expect(join.result).toHaveClarityType(ClarityType.ResponseOk);
+
+    const game = getGameTuple(gameId);
+    expect(game.value.winner).toBeNone();
+    expect(game.value.result).toEqual(Cl.stringAscii("tie"));
+
+    const creatorBalance = simnet.callReadOnlyFn(
+      contractName,
+      "get-balance",
+      [Cl.standardPrincipal(wallet1)],
+      wallet1,
+    );
+    expect(creatorBalance.result).toBeUint(stake);
+    const challengerBalance = simnet.callReadOnlyFn(
+      contractName,
+      "get-balance",
+      [Cl.standardPrincipal(wallet2)],
+      wallet2,
+    );
+    expect(challengerBalance.result).toBeUint(stake);
+  });
+
+  it("allows creator to cancel before a challenger joins and claim refund", () => {
+    const gameId = createGame(wallet1, "leaf");
+    const cancel = simnet.callPublicFn(
+      contractName,
+      "cancel-game",
+      [Cl.uint(gameId)],
+      wallet1,
+    );
+    expect(cancel.result).toBeOk(Cl.bool(true));
+
+    const game = getGameTuple(gameId);
+    expect(game.value.status).toEqual(Cl.uint(2));
+    expect(game.value.result).toEqual(Cl.stringAscii("canceled"));
+
+    const balance = simnet.callReadOnlyFn(
+      contractName,
+      "get-balance",
+      [Cl.standardPrincipal(wallet1)],
+      wallet1,
+    );
+    expect(balance.result).toBeUint(stake);
+  });
+
+  it("lets the winner claim their payout and zeroes owed balance", () => {
+    const gameId = createGame(wallet1, "fire");
+    simnet.callPublicFn(contractName, "join-game", [Cl.uint(gameId), Cl.stringAscii("leaf")], wallet2);
+
+    const owed = simnet.callReadOnlyFn(
+      contractName,
+      "get-balance",
+      [Cl.standardPrincipal(wallet1)],
+      wallet1,
+    );
+    expect(owed.result).toBeUint(stake * 2n);
+
+    const claim = simnet.callPublicFn(contractName, "claim", [], wallet1);
+    expect(claim.result).toBeOk(Cl.bool(true));
+
+    const cleared = simnet.callReadOnlyFn(
+      contractName,
+      "get-balance",
+      [Cl.standardPrincipal(wallet1)],
+      wallet1,
+    );
+    expect(cleared.result).toBeUint(0);
+  });
 });


### PR DESCRIPTION
  - Summary:
      - Implement a two-player emoji battle contract (fire/water/leaf) with stake escrow, settlement, cancel, and claim flows using Clarity 4 safe transfers and to-ascii logging.
      - Add state for games and balances plus helpers for contract principal, winner resolution, and payout crediting.
      - Replace placeholder tests with coverage for invalid emoji, winner, tie refunds, cancel, and claim.
  - Tests:
      - npx vitest run tests/emoji-battle.test.ts --pool=threads