### PR TITLE
Add Clarity guess-the-number game

### DIFF
--- a/stacks-arcade/contracts/guess-the-number.clar
+++ b/stacks-arcade/contracts/guess-the-number.clar
@@ -1,29 +1,40 @@
 ;; title: guess-the-number
-;; version:
-;; summary:
-;; description:
-
-;; traits
-;;
-
-;; token definitions
-;;
+;; version: 0.0.1
+;; summary: Single-player number guessing game with staked bets.
+;; description: Player stakes STX, guesses a number, and wins 2x if they match the on-chain draw.
 
 ;; constants
-;;
+(define-constant contract-version "0.0.1")
+(define-constant min-bet u1000000) ;; 0.01 STX
+(define-constant max-bet u100000000) ;; 1 STX
+(define-constant max-number u9) ;; guesses between 0-9
+(define-constant err-invalid-guess (err u400))
+(define-constant err-bet-low (err u401))
+(define-constant err-bet-high (err u402))
+(define-constant err-transfer (err u403))
+(define-constant err-zero-claim (err u404))
 
 ;; data vars
-;;
+(define-data-var next-game-id uint u0)
 
 ;; data maps
-;;
+;; game tuple: {id, player, wager, guess, draw, winner, at}
+(define-map games
+  {id: uint}
+  {
+    id: uint,
+    player: principal,
+    wager: uint,
+    guess: uint,
+    draw: uint,
+    winner: bool,
+    at: uint
+  }
+)
 
-;; public functions
-;;
+;; pending balances for withdrawals
+(define-map balances {player: principal} {amount: uint})
 
-;; read only functions
-;;
-
-;; private functions
-;;
-
+;; private helpers
+(define-private (contract-principal)
+  (unwrap-panic (as-contract? () tx-sender)))

--- a/stacks-arcade/contracts/guess-the-number.clar
+++ b/stacks-arcade/contracts/guess-the-number.clar
@@ -42,6 +42,7 @@
     (map-set balances {player: player} {amount: (+ current amount)})))
 
 (define-private (draw-number)
+  ;; simple, predictable draw for demo purposes only
   (mod (+ stacks-block-height stacks-block-time) (+ max-number u1)))
 
 ;; public functions

--- a/stacks-arcade/contracts/guess-the-number.clar
+++ b/stacks-arcade/contracts/guess-the-number.clar
@@ -31,8 +31,6 @@
     at: uint
   }
 )
-
-;; pending balances for withdrawals
 (define-map balances {player: principal} {amount: uint})
 
 ;; private helpers
@@ -51,48 +49,6 @@
   (let
     (
       (game-id (var-get next-game-id))
-      (self (contract-principal))
-      (at stacks-block-time)
-    )
-    (begin
-      (asserts! (<= guess max-number) err-invalid-guess)
-      (asserts! (>= wager min-bet) err-bet-low)
-      (asserts! (<= wager max-bet) err-bet-high)
-      (unwrap! (stx-transfer? wager tx-sender self) err-transfer)
-      (let
-        (
-          (draw (draw-number))
-          (winner (is-eq guess (draw-number)))
-          (payout (if winner (* wager u2) u0))
-        )
-        (begin
-          (map-set games {id: game-id}
-            {
-              id: game-id,
-              player: tx-sender,
-              wager: wager,
-              guess: guess,
-              draw: draw,
-              winner: winner,
-              at: at
-            })
-          (var-set next-game-id (+ game-id u1))
-          (if winner (credit tx-sender (* wager u2)) true)
-          (print {event: "play", id: game-id, player: tx-sender, guess: guess, draw: draw, winner: winner, payout: payout})
-          (ok {draw: draw, winner: winner})))))))
-
-(define-private (credit (player principal) (amount uint))
-  (let ((current (default-to u0 (get amount (map-get? balances {player: player})))))
-    (map-set balances {player: player} {amount: (+ current amount)})))
-
-(define-private (draw-number)
-  (mod (+ stacks-block-height stacks-block-time) (+ max-number u1)))
-
-;; public functions
-(define-public (play (guess uint) (wager uint))
-  (let
-    (
-      (game-id (var-get next-game-id))
       (draw (draw-number))
       (self (contract-principal))
       (played-at stacks-block-time)
@@ -106,9 +62,9 @@
         (
           (winner (is-eq guess draw))
           (payout (if (is-eq guess draw) (* wager u2) u0))
+          (winner-ascii (unwrap-panic (to-ascii? winner)))
         )
-        (when (> payout u0)
-          (credit tx-sender payout))
+        (if (> payout u0) (credit tx-sender payout) true)
         (map-set games {id: game-id}
           {
             id: game-id,
@@ -120,7 +76,7 @@
             at: played-at
           })
         (var-set next-game-id (+ game-id u1))
-        (print {event: "play", id: game-id, player: tx-sender, guess: guess, draw: draw, winner: winner, payout: payout})
+        (print {event: "play", id: game-id, player: tx-sender, guess: guess, draw: draw, winner: winner, winner-ascii: winner-ascii, payout: payout})
         (ok {draw: draw, winner: winner})))))
 
 (define-public (claim)


### PR DESCRIPTION
      - Implement single-player guess-the-number with staked wagers and on-chain draw; store results and payout winners.
      - Add claim handling and read-only helpers for balances, games, and version.
      - Clarinet check passes (existing emoji-battle warnings only).
