### PR TITLE
Add defensive tests for emoji-battle game

### DIFF
--- a/stacks-arcade/tests/emoji-battle.test.ts
+++ b/stacks-arcade/tests/emoji-battle.test.ts
@@ -39,6 +39,17 @@ describe("emoji-battle", () => {
     expect(res.result).toBeErr(Cl.uint(400));
   });
 
+  it("rejects invalid emoji on join", () => {
+    const gameId = createGame(wallet1, "fire");
+    const res = simnet.callPublicFn(
+      contractName,
+      "join-game",
+      [Cl.uint(gameId), Cl.stringAscii("invalid")],
+      wallet2,
+    );
+    expect(res.result).toBeErr(Cl.uint(400));
+  });
+
   it("settles a battle with a clear winner", () => {
     // fire beats leaf
     const gameId = createGame(wallet1, "fire");

--- a/stacks-arcade/tests/emoji-battle.test.ts
+++ b/stacks-arcade/tests/emoji-battle.test.ts
@@ -132,6 +132,11 @@ describe("emoji-battle", () => {
     expect(challengerBalance.result).toBeUint(stake);
   });
 
+  it("rejects a claim when balance is zero", () => {
+    const claim = simnet.callPublicFn(contractName, "claim", [], wallet2);
+    expect(claim.result).toBeErr(Cl.uint(408));
+  });
+
   it("allows creator to cancel before a challenger joins and claim refund", () => {
     const gameId = createGame(wallet1, "leaf");
     const cancel = simnet.callPublicFn(

--- a/stacks-arcade/tests/emoji-battle.test.ts
+++ b/stacks-arcade/tests/emoji-battle.test.ts
@@ -102,6 +102,28 @@ describe("emoji-battle", () => {
     expect(challengerBalance.result).toBeUint(0);
   });
 
+  it("blocks additional challengers once a game is settled", () => {
+    const gameId = createGame(wallet1, "fire");
+    const firstJoin = simnet.callPublicFn(
+      contractName,
+      "join-game",
+      [Cl.uint(gameId), Cl.stringAscii("leaf")],
+      wallet2,
+    );
+    expect(firstJoin.result).toBeOk(Cl.tuple({ result: Cl.stringAscii("creator"), winner: Cl.some(Cl.standardPrincipal(wallet1)) }));
+
+    const secondJoin = simnet.callPublicFn(
+      contractName,
+      "join-game",
+      [Cl.uint(gameId), Cl.stringAscii("water")],
+      wallet1,
+    );
+    expect(secondJoin.result).toBeErr(Cl.uint(403));
+
+    const game = getGameTuple(gameId);
+    expect(game.value.status).toEqual(Cl.uint(1));
+  });
+
   it("refunds both players on a tie", () => {
     const gameId = createGame(wallet1, "water");
     const join = simnet.callPublicFn(

--- a/stacks-arcade/tests/emoji-battle.test.ts
+++ b/stacks-arcade/tests/emoji-battle.test.ts
@@ -50,6 +50,21 @@ describe("emoji-battle", () => {
     expect(res.result).toBeErr(Cl.uint(400));
   });
 
+  it("prevents a creator from joining their own game", () => {
+    const gameId = createGame(wallet1, "water");
+    const res = simnet.callPublicFn(
+      contractName,
+      "join-game",
+      [Cl.uint(gameId), Cl.stringAscii("fire")],
+      wallet1,
+    );
+    expect(res.result).toBeErr(Cl.uint(405));
+
+    const game = getGameTuple(gameId);
+    expect(game.value.status).toEqual(Cl.uint(0));
+    expect(game.value.challenger).toBeNone();
+  });
+
   it("settles a battle with a clear winner", () => {
     // fire beats leaf
     const gameId = createGame(wallet1, "fire");


### PR DESCRIPTION

  - cover invalid join emojis and self-join rejection
  - assert zero-balance claims fail with err u408
  - ensure settled games refuse additional challengers
  - keep winner/tie/cancel and claim flows passing with updated coverage